### PR TITLE
React native buffer fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/synonymdev/backpack-client#readme",
   "dependencies": {
-    "@synonymdev/slashtags-sdk": "^1.0.0-alpha.2",
+    "@synonymdev/slashtags-sdk": "1.0.0-alpha.12",
     "compact-encoding": "^2.7.0",
     "compact-encoding-struct": "^1.3.0",
     "sodium-universal": "^3.1.0"

--- a/src/comms-protocol.js
+++ b/src/comms-protocol.js
@@ -166,7 +166,7 @@ export default class SlashCommsProtocol extends SlashProtocol {
      * @returns
      */
     _generateMessageToHash(msg, timestamp) {
-        return Buffer.concat([msg, Buffer.from(`${timestamp}`)])
+        return Buffer([...msg, ...Buffer.from(`${timestamp}`)])
     }
 }
 


### PR DESCRIPTION
Buffer not supported in react native out of the box and the rn-nodify version for this seems to not support `Buffer.concat`. Joining with spread works fine in RN.

![Simulator Screen Shot - iPhone 13 - 2022-07-21 at 12 38 45](https://user-images.githubusercontent.com/5300488/180198562-83225ff2-b27a-44bf-8a93-1bc5ed1185b5.png)
